### PR TITLE
feat(release-drafter): add pr label using release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,6 +5,9 @@ categories:
     labels:
       - 'feature'
       - 'enhancement'
+  - title: '📝 Refactor'
+    labels:
+      - 'refactor'
   - title: '🐛 Bug Fixes'
     labels:
       - 'fix'


### PR DESCRIPTION
This PR retires PR Labeler actions and leverages Release Drafter `autolabeler` option